### PR TITLE
Nickname isn't display name

### DIFF
--- a/web/models/auth.ex
+++ b/web/models/auth.ex
@@ -2,9 +2,10 @@ defmodule Cazoc.Auth do
   use Cazoc.Web, :model
 
   def insert_or_update(%Ueberauth.Auth{} = auth) do
-    name = name_from_auth(auth)
+    display_name = display_name_from_auth(auth)
+    name = auth.info.nickname
     params = %{email: auth.info.email,
-               display_name: auth.info.nickname,
+               display_name: display_name,
                icon: auth.info.urls.avatar_url,
                url: auth.info.urls.blog}
     case Repo.get_by(Author, name: name) do
@@ -16,7 +17,7 @@ defmodule Cazoc.Auth do
     |> Service.insert_or_update(auth)
   end
 
-  defp name_from_auth(auth) do
+  defp display_name_from_auth(auth) do
     if auth.info.name do
       auth.info.name
     else

--- a/web/templates/layout/app.html.slime
+++ b/web/templates/layout/app.html.slime
@@ -21,7 +21,7 @@ html lang="en"
             a.dropdown-toggle data-toggle="dropdown" href="#" type="button" aria-haspopup="true" aria-expanded="false"
               img.author-icon.img-circle src="#{current_author(@conn).icon}" alt="author icon"
             ul.dropdown-menu.dropdown-menu-right.global_menu
-              li.dropdown-header = current_author(@conn).name
+              li.dropdown-header = current_author(@conn).display_name
               li.dropdown-divider
               li.dropdown-item = link "Families", to: my_family_path(@conn, :index)
               li.dropdown-item = link "Import", to: github_path(@conn, :index)

--- a/web/templates/search/index.html.slime
+++ b/web/templates/search/index.html.slime
@@ -7,4 +7,4 @@
         tr
           td.subtitle = article |> Cazoc.Article.formated_publised_at
           td = link article.title, to: my_article_path(@conn, :show, article), class: "btn btn-default btn-xs"
-          td = article.author.name
+          td = article.author.display_name


### PR DESCRIPTION
## Problem

Failed article import if "display_name" and "name" are different.

## Solution

Name should be taken from auth.info.nickname. Because, auth.info.nickname is taken from "login" of GitHub API.

https://github.com/ueberauth/ueberauth_github/blob/v0.2.0/lib/ueberauth/strategy/github.ex#L159-L160